### PR TITLE
Add FastAPI API server with session endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,13 @@ anthropic = "^0.18.1"
 python-dotenv = "^1.0.0"
 rich = "^13.7.0"
 prompt-toolkit = "^3.0.43"
+fastapi = "^0.111.0"
+uvicorn = "^0.29.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.4.4"
-pytest-asyncio = "^0.23.3"
+pytest-asyncio = "^0.23.6"
+httpx = "^0.26.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/rd_assistant/api/__init__.py
+++ b/src/rd_assistant/api/__init__.py
@@ -1,0 +1,5 @@
+"""API package for RD-Assistant."""
+
+from .server import app
+
+__all__ = ["app"]

--- a/src/rd_assistant/api/server.py
+++ b/src/rd_assistant/api/server.py
@@ -1,0 +1,53 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from uuid import uuid4
+from typing import Dict
+
+from ..config import Config
+from ..llm.service import LLMServiceFactory
+from ..core.analyzer import RequirementAnalyzer
+from ..core.storage import SessionStorage
+
+app = FastAPI()
+
+# Initialize core services
+config = Config()
+llm_service = LLMServiceFactory.create(config.get_llm_config())
+storage = SessionStorage(config.get_session_config().get('save_dir', 'sessions'))
+
+# In-memory session storage
+_sessions: Dict[str, RequirementAnalyzer] = {}
+
+class MessagePayload(BaseModel):
+    message: str
+
+@app.post("/sessions")
+async def create_session() -> Dict[str, str]:
+    """Create a new analyzer session and return its ID."""
+    session_id = str(uuid4())
+    analyzer = RequirementAnalyzer(llm_service)
+    _sessions[session_id] = analyzer
+    # Persist empty session
+    storage.save_session(analyzer.memory)
+    return {"session_id": session_id}
+
+@app.post("/sessions/{session_id}/messages")
+async def send_message(session_id: str, payload: MessagePayload) -> Dict:
+    """Send a user message to the analyzer and return the result."""
+    analyzer = _sessions.get(session_id)
+    if not analyzer:
+        raise HTTPException(status_code=404, detail="Session not found")
+    response = await analyzer.process_input(payload.message)
+    storage.save_session(analyzer.memory)
+    return {"result": response}
+
+@app.get("/sessions/{session_id}/status")
+async def session_status(session_id: str) -> Dict:
+    """Return summary status for the given session."""
+    analyzer = _sessions.get(session_id)
+    if not analyzer:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return analyzer.get_current_status()
+
+# Expose sessions dictionary for testing
+sessions = _sessions

--- a/tests/api/test_server.py
+++ b/tests/api/test_server.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import pytest
+from httpx import AsyncClient
+
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, os.path.join(BASE_DIR, "src"))
+from rd_assistant.api import server
+
+@pytest.mark.asyncio
+async def test_session_lifecycle(monkeypatch):
+    async def fake_process_input(self, message: str):
+        return {"echo": message}
+
+    monkeypatch.setattr(server.RequirementAnalyzer, "process_input", fake_process_input)
+    monkeypatch.setattr(server.storage, "save_session", lambda memory: "dummy")
+
+    async with AsyncClient(app=server.app, base_url="http://test") as ac:
+        res = await ac.post("/sessions")
+        assert res.status_code == 200
+        session_id = res.json()["session_id"]
+        assert session_id in server.sessions
+
+        res2 = await ac.post(f"/sessions/{session_id}/messages", json={"message": "hello"})
+        assert res2.status_code == 200
+        assert res2.json()["result"] == {"echo": "hello"}
+
+        res3 = await ac.get(f"/sessions/{session_id}/status")
+        assert res3.status_code == 200
+        assert isinstance(res3.json(), dict)


### PR DESCRIPTION
## Summary
- create `src/rd_assistant/api` module with FastAPI server
- maintain in-memory sessions and persist via `SessionStorage`
- add dependencies `fastapi`, `uvicorn`, and upgrade `pytest-asyncio`
- implement async API tests using pytest and pytest-asyncio

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404facdd7c83328559610881687014