### PR TITLE
Add simple frontend and visualization API

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,17 @@ cp .env.example .env
 poetry run python -m src.rd_assistant.main
 ```
 
+### Web インターフェースの起動
+
+1. バックエンドサーバーの起動
+
+```bash
+poetry run uvicorn rd_assistant.api.server:app --reload
+```
+
+2. 別ターミナルで `frontend/index.html` をブラウザで開きます。
+   このページは自動的にセッションを作成し、チャット結果と要件図を表示します。
+
 ## 環境変数について
 
 - `AZURE_OPENAI_API_KEY`: Azure OpenAI ServiceのAPIキー

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,56 @@
+let sessionId = null;
+
+async function initSession() {
+  const res = await fetch('/sessions', { method: 'POST' });
+  const data = await res.json();
+  sessionId = data.session_id;
+  await loadVisualization();
+}
+
+async function sendMessage(text) {
+  const res = await fetch(`/sessions/${sessionId}/messages`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message: text })
+  });
+  return await res.json();
+}
+
+async function loadVisualization() {
+  const res = await fetch(`/sessions/${sessionId}/visualization`);
+  const data = await res.json();
+  const diagramEl = document.getElementById('diagram');
+  diagramEl.textContent = data.diagram;
+  mermaid.run({ nodes: [diagramEl] });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initSession();
+  const form = document.getElementById('chat-form');
+  const input = document.getElementById('message-input');
+  const chat = document.getElementById('chat');
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const text = input.value.trim();
+    if (!text) return;
+    appendMessage('user', text);
+    input.value = '';
+    const resp = await sendMessage(text);
+    if (resp.result && resp.result.response) {
+      appendMessage('ai', resp.result.response.message);
+    } else {
+      appendMessage('ai', JSON.stringify(resp));
+    }
+    await loadVisualization();
+  });
+});
+
+function appendMessage(role, text) {
+  const div = document.createElement('div');
+  div.className = role;
+  div.textContent = text;
+  const chat = document.getElementById('chat');
+  chat.appendChild(div);
+  chat.scrollTop = chat.scrollHeight;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>RD Assistant</title>
+<link rel="stylesheet" href="styles.css">
+<script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+</head>
+<body>
+<div id="container">
+  <div id="chat-pane">
+    <div id="chat"></div>
+    <form id="chat-form">
+      <input id="message-input" type="text" placeholder="Type a message" autocomplete="off" />
+      <button type="submit">Send</button>
+    </form>
+  </div>
+  <div id="diagram-pane">
+    <pre id="diagram"></pre>
+  </div>
+</div>
+<script src="app.js"></script>
+</body>
+</html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,33 @@
+html, body {
+  height: 100%;
+  margin: 0;
+  font-family: sans-serif;
+}
+#container {
+  display: flex;
+  height: 100%;
+}
+#chat-pane {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid #ccc;
+}
+#chat {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1em;
+}
+#chat-form {
+  display: flex;
+  border-top: 1px solid #ccc;
+}
+#message-input {
+  flex: 1;
+  padding: 0.5em;
+}
+#diagram-pane {
+  flex: 1;
+  padding: 1em;
+  overflow-y: auto;
+}

--- a/src/rd_assistant/api/server.py
+++ b/src/rd_assistant/api/server.py
@@ -3,6 +3,8 @@ from pydantic import BaseModel
 from uuid import uuid4
 from typing import Dict
 
+from ..core.visualizer import RequirementsVisualizer
+
 from ..config import Config
 from ..llm.service import LLMServiceFactory
 from ..core.analyzer import RequirementAnalyzer
@@ -48,6 +50,20 @@ async def session_status(session_id: str) -> Dict:
     if not analyzer:
         raise HTTPException(status_code=404, detail="Session not found")
     return analyzer.get_current_status()
+
+
+@app.get("/sessions/{session_id}/visualization")
+async def session_visualization(session_id: str, diagram_type: str = "mindmap") -> Dict[str, str]:
+    """Return Mermaid diagram text for the given session."""
+    analyzer = _sessions.get(session_id)
+    if not analyzer:
+        raise HTTPException(status_code=404, detail="Session not found")
+    visualizer = RequirementsVisualizer()
+    if diagram_type == "flowchart":
+        diagram = visualizer.generate_flowchart(analyzer.memory)
+    else:
+        diagram = visualizer.generate_mindmap(analyzer.memory)
+    return {"diagram": diagram}
 
 # Expose sessions dictionary for testing
 sessions = _sessions

--- a/tests/api/test_server.py
+++ b/tests/api/test_server.py
@@ -28,3 +28,7 @@ async def test_session_lifecycle(monkeypatch):
         res3 = await ac.get(f"/sessions/{session_id}/status")
         assert res3.status_code == 200
         assert isinstance(res3.json(), dict)
+
+        res4 = await ac.get(f"/sessions/{session_id}/visualization")
+        assert res4.status_code == 200
+        assert "mindmap" in res4.json()["diagram"]


### PR DESCRIPTION
## Summary
- provide basic HTML/CSS/JS frontend
- expose `/sessions/{session_id}/visualization` endpoint
- test new endpoint
- document launching backend and UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840567640308332aff11e6d3cb534c0