### PR TITLE
Remove duplicate _group_requirements

### DIFF
--- a/src/rd_assistant/core/visualizer.py
+++ b/src/rd_assistant/core/visualizer.py
@@ -111,21 +111,6 @@ class RequirementsVisualizer:
         
         return "\n".join(lines)
 
-    def _group_requirements(self, requirements: List[Requirement]) -> Dict[str, List[Requirement]]:
-        """要件をタイプごとにグループ化"""
-        grouped = {
-            "functional": [],
-            "non_functional": [],
-            "technical": [],
-            "business": []
-        }
-        
-        for req in requirements:
-            if req.type in grouped:
-                grouped[req.type].append(req)
-        
-        return grouped
-
     def _get_requirement_type_name(self, req_type: str) -> str:
         """要件タイプの日本語名を取得"""
         return {


### PR DESCRIPTION
## Summary
- deduplicate the `_group_requirements` helper in `visualizer.py`
- keep a single implementation and retain all calls
- ensure file ends with a newline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684058f2f17483328f86c913f6d96e5b