### PR TITLE
Improve chat UI

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,13 +1,38 @@
 let sessionId = null;
+let isDarkMode = true;
+let isLoading = false;
+let customImages = { userAvatar: null, botAvatar: null };
+
+function loadSettings() {
+  const imgs = localStorage.getItem('chatCustomImages');
+  if (imgs) customImages = JSON.parse(imgs);
+  const theme = localStorage.getItem('chatTheme');
+  if (theme) {
+    isDarkMode = theme === 'dark';
+    document.body.className = isDarkMode ? 'dark' : 'light';
+  }
+  updateAvatarPreview('user');
+  updateAvatarPreview('bot');
+}
+
+function saveSettings() {
+  localStorage.setItem('chatCustomImages', JSON.stringify(customImages));
+  localStorage.setItem('chatTheme', isDarkMode ? 'dark' : 'light');
+}
 
 async function initSession() {
   const res = await fetch('/sessions', { method: 'POST' });
   const data = await res.json();
   sessionId = data.session_id;
   await loadVisualization();
+  addInitialMessage();
 }
 
-async function sendMessage(text) {
+function addInitialMessage() {
+  addMessage('👋 Hello! Ask me anything.', 'bot');
+}
+
+async function sendMessageToServer(text) {
   const res = await fetch(`/sessions/${sessionId}/messages`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -24,33 +49,177 @@ async function loadVisualization() {
   mermaid.run({ nodes: [diagramEl] });
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-  initSession();
-  const form = document.getElementById('chat-form');
+function onSend() {
   const input = document.getElementById('message-input');
-  const chat = document.getElementById('chat');
-
-  form.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    const text = input.value.trim();
-    if (!text) return;
-    appendMessage('user', text);
-    input.value = '';
-    const resp = await sendMessage(text);
+  const text = input.value.trim();
+  if (!text || isLoading) return;
+  addMessage(text, 'user');
+  input.value = '';
+  input.style.height = 'auto';
+  startLoading();
+  sendMessageToServer(text).then(resp => {
+    stopLoading();
     if (resp.result && resp.result.response) {
-      appendMessage('ai', resp.result.response.message);
+      addMessage(resp.result.response.message, 'bot');
     } else {
-      appendMessage('ai', JSON.stringify(resp));
+      addMessage(JSON.stringify(resp), 'bot');
     }
-    await loadVisualization();
+    loadVisualization();
   });
+}
+
+function addMessage(content, type) {
+  const messagesArea = document.getElementById('messagesArea');
+  const div = document.createElement('div');
+  div.className = `message ${type}`;
+  div.innerHTML = `
+    <div class="avatar ${type}">
+      <div class="avatar-inner">
+        ${type === 'user' ? getUserAvatarSVG() : getBotAvatarSVG()}
+      </div>
+    </div>
+    <div class="message-bubble">
+      <div>${renderMarkdown(content)}</div>
+      <div class="message-time">${new Date().toLocaleTimeString('en-US',{hour:'2-digit',minute:'2-digit'})}</div>
+    </div>`;
+  messagesArea.appendChild(div);
+  messagesArea.scrollTop = messagesArea.scrollHeight;
+}
+
+function startLoading() {
+  isLoading = true;
+  const messagesArea = document.getElementById('messagesArea');
+  const loadingDiv = document.createElement('div');
+  loadingDiv.className = 'message bot';
+  loadingDiv.id = 'loadingMessage';
+  loadingDiv.innerHTML = `
+    <div class="avatar bot">
+      <div class="avatar-inner">
+        ${getBotAvatarSVG(true)}
+      </div>
+    </div>
+    <div class="message-bubble">
+      <div class="loading-message">
+        <div class="loading-dots">
+          <div class="loading-dot"></div>
+          <div class="loading-dot"></div>
+          <div class="loading-dot"></div>
+        </div>
+        <span>Thinking...</span>
+      </div>
+    </div>`;
+  messagesArea.appendChild(loadingDiv);
+  messagesArea.scrollTop = messagesArea.scrollHeight;
+  document.getElementById('sendButton').disabled = true;
+}
+
+function stopLoading() {
+  isLoading = false;
+  const loadingMessage = document.getElementById('loadingMessage');
+  if (loadingMessage) loadingMessage.remove();
+  document.getElementById('sendButton').disabled = false;
+  document.getElementById('message-input').focus();
+}
+
+function renderMarkdown(text) {
+  return text
+    .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*(.*?)\*/g, '<em>$1</em>')
+    .replace(/`([^`]+)`/g, '<code style="background-color: rgba(156,163,175,0.2); padding: 0.125rem 0.25rem; border-radius: 0.25rem; font-size: 0.875rem;">$1</code>')
+    .replace(/\n/g, '<br>');
+}
+
+function getUserAvatarSVG() {
+  if (customImages.userAvatar) {
+    return `<img src="${customImages.userAvatar}" alt="user avatar" class="avatar-custom">`;
+  }
+  return `<svg viewBox="0 0 100 100"><circle cx="50" cy="45" r="35" fill="#fbbf24" stroke="#f59e0b" stroke-width="2"/><circle cx="42" cy="38" r="3" fill="#1f2937"/><circle cx="58" cy="38" r="3" fill="#1f2937"/><circle cx="43" cy="37" r="1" fill="white"/><circle cx="59" cy="37" r="1" fill="white"/><path d="M50,42 Q52,45 50,48" stroke="#f59e0b" stroke-width="1.5" fill="none"/><path d="M45,52 Q50,57 55,52" stroke="#dc2626" stroke-width="2" fill="none"/><path d="M20,35 Q25,15 50,20 Q75,15 80,35 Q75,25 50,25 Q25,25 20,35" fill="#7c2d12"/></svg>`;
+}
+
+function getBotAvatarSVG(anim=false) {
+  if (customImages.botAvatar) {
+    return `<img src="${customImages.botAvatar}" alt="bot avatar" class="avatar-custom">`;
+  }
+  const eye = anim ? '#10b981' : '#3b82f6';
+  const antenna = anim ? '#10b981' : '#ef4444';
+  return `<svg viewBox="0 0 100 100"><rect x="25" y="20" width="50" height="45" rx="25" fill="#e5e7eb" stroke="#9ca3af" stroke-width="2"/><circle cx="38" cy="35" r="4" fill="${eye}"/><circle cx="62" cy="35" r="4" fill="${eye}"/><ellipse cx="50" cy="50" rx="${anim?'8':'6'}" ry="${anim?'4':'2'}" fill="#1f2937"/><rect x="48" y="15" width="4" height="8" fill="#9ca3af"/><circle cx="50" cy="12" r="3" fill="${antenna}"/><rect x="30" y="42" width="6" height="2" rx="1" fill="#6b7280"/><rect x="64" y="42" width="6" height="2" rx="1" fill="#6b7280"/></svg>`;
+}
+
+function openSettings() {
+  document.getElementById('settingsOverlay').style.display = 'flex';
+}
+
+function closeSettings() {
+  document.getElementById('settingsOverlay').style.display = 'none';
+}
+
+document.getElementById('settingsOverlay').addEventListener('click', e => {
+  if (e.target === e.currentTarget) closeSettings();
 });
 
-function appendMessage(role, text) {
-  const div = document.createElement('div');
-  div.className = role;
-  div.textContent = text;
-  const chat = document.getElementById('chat');
-  chat.appendChild(div);
-  chat.scrollTop = chat.scrollHeight;
+function selectUserAvatar() { document.getElementById('userAvatarInput').click(); }
+function selectBotAvatar() { document.getElementById('botAvatarInput').click(); }
+
+function readFileAsDataURL(file) { return new Promise((res, rej) => { const r = new FileReader(); r.onload = e => res(e.target.result); r.onerror = rej; r.readAsDataURL(file); }); }
+
+async function handleUserAvatarUpload(e) {
+  const file = e.target.files[0];
+  if (!file) return;
+  if (file.size > 2 * 1024 * 1024) { alert('File too big'); return; }
+  const dataURL = await readFileAsDataURL(file);
+  customImages.userAvatar = dataURL;
+  updateAvatarPreview('user');
+  saveSettings();
 }
+
+async function handleBotAvatarUpload(e) {
+  const file = e.target.files[0];
+  if (!file) return;
+  if (file.size > 2 * 1024 * 1024) { alert('File too big'); return; }
+  const dataURL = await readFileAsDataURL(file);
+  customImages.botAvatar = dataURL;
+  updateAvatarPreview('bot');
+  saveSettings();
+}
+
+function updateAvatarPreview(type) {
+  const previewId = type === 'user' ? 'userAvatarPreview' : 'botAvatarPreview';
+  const areaId = type === 'user' ? 'userAvatarArea' : 'botAvatarArea';
+  const img = type === 'user' ? customImages.userAvatar : customImages.botAvatar;
+  const preview = document.getElementById(previewId);
+  const area = document.getElementById(areaId);
+  if (img) {
+    preview.innerHTML = `<img src="${img}" class="image-preview" style="border-radius:50%;"><div class="upload-text">Change</div>`;
+    area.classList.add('has-image');
+  } else {
+    preview.innerHTML = `<div class="upload-icon"><svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1"><path d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"/></svg></div><div class="upload-text">Upload Image</div><div class="upload-hint">Click to choose</div>`;
+    area.classList.remove('has-image');
+  }
+}
+
+function resetUserAvatar() { customImages.userAvatar = null; updateAvatarPreview('user'); saveSettings(); }
+function resetBotAvatar() { customImages.botAvatar = null; updateAvatarPreview('bot'); saveSettings(); }
+
+function toggleTheme() {
+  isDarkMode = !isDarkMode;
+  document.body.className = isDarkMode ? 'dark' : 'light';
+  saveSettings();
+  const toggleButton = document.getElementById('themeToggle');
+  toggleButton.innerHTML = isDarkMode ?
+    `<svg width="18" height="18" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>` :
+    `<svg width="18" height="18" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>`;
+}
+
+document.getElementById('message-input').addEventListener('keypress', e => {
+  if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); onSend(); }
+});
+
+document.getElementById('message-input').addEventListener('input', e => {
+  e.target.style.height = 'auto';
+  e.target.style.height = e.target.scrollHeight + 'px';
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadSettings();
+  initSession();
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,24 +1,112 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="UTF-8">
-<title>RD Assistant</title>
-<link rel="stylesheet" href="styles.css">
-<script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+    <meta charset="UTF-8">
+    <title>RD Assistant</title>
+    <link rel="stylesheet" href="styles.css">
+    <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
 </head>
-<body>
+<body class="dark">
 <div id="container">
-  <div id="chat-pane">
-    <div id="chat"></div>
-    <form id="chat-form">
-      <input id="message-input" type="text" placeholder="Type a message" autocomplete="off" />
-      <button type="submit">Send</button>
-    </form>
-  </div>
-  <div id="diagram-pane">
-    <pre id="diagram"></pre>
-  </div>
+    <div id="chat-pane" class="chat-container">
+        <header class="header">
+            <div class="header-title">
+                <div class="title-icon">
+                    <svg width="16" height="16" fill="none" stroke="white" viewBox="0 0 24 24" stroke-width="2">
+                        <path d="M12 2L2 7v10c0 5.55 3.84 10 9 9 5.16 1 9-3.45 9-9V7L12 2z"/>
+                        <path d="M12 2L22 7"/>
+                        <path d="M12 2L2 7"/>
+                        <path d="M8 12l2 2 4-4"/>
+                    </svg>
+                </div>
+                <h1 class="title-text">RD Assistant</h1>
+            </div>
+            <div class="header-controls">
+                <button class="settings-button" onclick="openSettings()" id="settingsButton">
+                    <svg width="18" height="18" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                        <circle cx="12" cy="12" r="3"/>
+                        <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-2 2 2 2 0 01-2-2v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83 0 2 2 0 010-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 01-2-2 2 2 0 012-2h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 010-2.83 2 2 0 012.83 0l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 012-2 2 2 0 012 2v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 0 2 2 0 010 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 012 2 2 2 0 01-2 2h-.09a1.65 1.65 0 00-1.51 1z"/>
+                    </svg>
+                </button>
+                <button class="theme-toggle" onclick="toggleTheme()" id="themeToggle">
+                    <svg width="18" height="18" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                        <circle cx="12" cy="12" r="5"/>
+                        <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>
+                    </svg>
+                </button>
+            </div>
+        </header>
+
+        <div class="messages-area" id="messagesArea"></div>
+
+        <div class="input-area">
+            <div class="input-container">
+                <div class="input-wrapper">
+                    <textarea id="message-input" class="input-field" placeholder="Type a message..." rows="1"></textarea>
+                </div>
+                <button class="send-button" id="sendButton" onclick="onSend()">
+                    <svg width="20" height="20" fill="none" stroke="white" viewBox="0 0 24 24" stroke-width="2">
+                        <path d="M22 2L11 13"/>
+                        <path d="M22 2L15 22L11 13L2 9L22 2z"/>
+                    </svg>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div id="diagram-pane">
+        <pre id="diagram"></pre>
+    </div>
 </div>
+
+<div class="settings-overlay" id="settingsOverlay">
+    <div class="settings-panel">
+        <div class="settings-header">
+            <h2 class="settings-title">Settings</h2>
+            <button class="close-button" onclick="closeSettings()">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                    <path d="M18 6L6 18M6 6l12 12"/>
+                </svg>
+            </button>
+        </div>
+        <div class="setting-group">
+            <label class="setting-label">User Avatar</label>
+            <div class="image-upload-area" onclick="selectUserAvatar()" id="userAvatarArea">
+                <div id="userAvatarPreview">
+                    <div class="upload-icon">
+                        <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1">
+                            <path d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"/>
+                        </svg>
+                    </div>
+                    <div class="upload-text">Upload Image</div>
+                    <div class="upload-hint">Click to choose</div>
+                </div>
+            </div>
+            <div class="image-actions">
+                <button class="action-button" onclick="resetUserAvatar()">Reset</button>
+            </div>
+            <input type="file" id="userAvatarInput" accept="image/*" style="display:none" onchange="handleUserAvatarUpload(event)">
+        </div>
+        <div class="setting-group">
+            <label class="setting-label">Bot Avatar</label>
+            <div class="image-upload-area" onclick="selectBotAvatar()" id="botAvatarArea">
+                <div id="botAvatarPreview">
+                    <div class="upload-icon">
+                        <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1">
+                            <path d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"/>
+                        </svg>
+                    </div>
+                    <div class="upload-text">Upload Image</div>
+                    <div class="upload-hint">Click to choose</div>
+                </div>
+            </div>
+            <div class="image-actions">
+                <button class="action-button" onclick="resetBotAvatar()">Reset</button>
+            </div>
+            <input type="file" id="botAvatarInput" accept="image/*" style="display:none" onchange="handleBotAvatarUpload(event)">
+        </div>
+    </div>
+</div>
+
 <script src="app.js"></script>
 </body>
 </html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,33 +1,93 @@
-html, body {
-  height: 100%;
-  margin: 0;
-  font-family: sans-serif;
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', sans-serif;
+    height: 100vh;
+    overflow: hidden;
+    transition: all 0.3s ease;
 }
-#container {
-  display: flex;
-  height: 100%;
-}
-#chat-pane {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  border-right: 1px solid #ccc;
-}
-#chat {
-  flex: 1;
-  overflow-y: auto;
-  padding: 1em;
-}
-#chat-form {
-  display: flex;
-  border-top: 1px solid #ccc;
-}
-#message-input {
-  flex: 1;
-  padding: 0.5em;
-}
-#diagram-pane {
-  flex: 1;
-  padding: 1em;
-  overflow-y: auto;
-}
+.dark { background-color: #111827; color: #f9fafb; }
+.light { background-color: #f9fafb; color: #111827; }
+#container { display: flex; height: 100vh; }
+#diagram-pane { flex: 1; padding: 1rem; overflow-y: auto; }
+#chat-pane { flex: 1; display: flex; flex-direction: column; border-right: 1px solid #374151; }
+.light #chat-pane { border-color: #e5e7eb; }
+.chat-container { display: flex; flex-direction: column; height: 100%; }
+.header { padding: 1rem 1.5rem; border-bottom: 1px solid; backdrop-filter: blur(12px); display: flex; justify-content: space-between; align-items: center; box-shadow: 0 20px 25px -5px rgba(0,0,0,0.1); }
+.dark .header { background-color: rgba(17,24,39,0.8); border-color: #374151; box-shadow: 0 20px 25px -5px rgba(17,24,39,0.2); }
+.light .header { background-color: rgba(255,255,255,0.8); border-color: #e5e7eb; }
+.header-title { display: flex; align-items: center; gap: 0.75rem; }
+.title-icon { width: 2rem; height: 2rem; border-radius: 50%; background: linear-gradient(to bottom right, #10b981, #3b82f6); display: flex; align-items: center; justify-content: center; }
+.title-icon svg { width: 16px; height: 16px; stroke: white; fill: none; }
+.title-text { font-size: 1.25rem; font-weight: bold; background: linear-gradient(to right, #10b981, #3b82f6); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
+.header-controls { display: flex; align-items: center; gap: 0.5rem; }
+.settings-button, .theme-toggle { padding: 0.5rem; border-radius: 50%; border: none; cursor: pointer; transition: all 0.3s ease; display: flex; align-items: center; justify-content: center; }
+.dark .settings-button, .dark .theme-toggle { background-color: #1f2937; border: 1px solid #374151; color: #9ca3af; }
+.light .settings-button, .light .theme-toggle { background-color: #f3f4f6; border: 1px solid #d1d5db; color: #4b5563; }
+.settings-button:hover, .theme-toggle:hover { transform: scale(1.1); }
+.settings-button svg, .theme-toggle svg { width: 18px; height: 18px; stroke: currentColor; fill: none; }
+.messages-area { flex: 1; overflow-y: auto; padding: 1.5rem; display: flex; flex-direction: column; gap: 1.5rem; }
+.message { display: flex; align-items: flex-start; gap: 1rem; max-width: 48rem; }
+.message.user { flex-direction: row-reverse; margin-left: auto; }
+.avatar { width: 4rem; height: 4rem; border-radius: 50%; padding: 2px; box-shadow: 0 25px 50px -12px rgba(0,0,0,0.25); position: relative; }
+.avatar.user { background: linear-gradient(to bottom right, #3b82f6, #8b5cf6, #ec4899); }
+.avatar.bot { background: linear-gradient(to bottom right, #10b981, #3b82f6, #8b5cf6); }
+.avatar-inner { width: 100%; height: 100%; border-radius: 50%; background-color: #111827; display: flex; align-items: center; justify-content: center; overflow: hidden; }
+.message-bubble { border-radius: 1.5rem; padding: 1.5rem; box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1); transition: all 0.3s ease; }
+.message-bubble:hover { box-shadow: 0 20px 25px -5px rgba(0,0,0,0.15); }
+.message.user .message-bubble { background: linear-gradient(to bottom right, #3b82f6, #8b5cf6); color: white; }
+.dark .message.bot .message-bubble { background-color: #1f2937; border: 1px solid #374151; color: #f9fafb; }
+.light .message.bot .message-bubble { background-color: white; border: 1px solid #e5e7eb; color: #1f2937; }
+.message-time { font-size: 0.75rem; margin-top: 0.75rem; opacity: 0.7; }
+.loading-message { display: flex; align-items: center; gap: 0.5rem; }
+.loading-dots { display: flex; gap: 0.25rem; }
+.loading-dot { width: 0.5rem; height: 0.5rem; border-radius: 50%; animation: bounce 1.4s infinite ease-in-out; }
+.loading-dot:nth-child(1) { background-color: #10b981; }
+.loading-dot:nth-child(2) { background-color: #3b82f6; animation-delay: -0.16s; }
+.loading-dot:nth-child(3) { background-color: #8b5cf6; animation-delay: -0.32s; }
+.input-area { padding: 1rem 1.5rem; border-top: 1px solid; backdrop-filter: blur(12px); }
+.dark .input-area { background-color: rgba(17,24,39,0.8); border-color: #374151; }
+.light .input-area { background-color: rgba(255,255,255,0.8); border-color: #e5e7eb; }
+.input-container { display: flex; align-items: flex-end; gap: 1rem; }
+.input-wrapper { flex: 1; position: relative; }
+.input-field { width: 100%; border-radius: 1.5rem; padding: 1rem 1.5rem; border: 1px solid; resize: none; min-height: 3.5rem; max-height: 8.75rem; transition: all 0.3s ease; font-family: inherit; }
+.dark .input-field { background-color: #1f2937; border-color: #4b5563; color: #f9fafb; }
+.light .input-field { background-color: #f9fafb; border-color: #d1d5db; color: #1f2937; }
+.input-field:focus { outline: none; border-color: #10b981; box-shadow: 0 0 0 3px rgba(16,185,129,0.1); }
+.send-button { background: linear-gradient(to bottom right, #10b981, #3b82f6); color: white; border: none; border-radius: 1.5rem; padding: 1rem; cursor: pointer; transition: all 0.3s ease; display: flex; align-items: center; justify-content: center; min-width: 3.5rem; min-height: 3.5rem; }
+.send-button:hover:not(:disabled) { transform: scale(1.05); box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1); }
+.send-button:disabled { opacity: 0.5; cursor: not-allowed; background: linear-gradient(to bottom right, #6b7280, #9ca3af); }
+.send-button svg { width: 20px; height: 20px; stroke: white; fill: none; stroke-width: 2; }
+.settings-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background-color: rgba(0,0,0,0.5); display: none; justify-content: center; align-items: center; z-index: 100; backdrop-filter: blur(4px); }
+.settings-panel { border-radius: 1rem; padding: 2rem; width: 90%; max-width: 500px; max-height: 80vh; overflow-y: auto; box-shadow: 0 25px 50px -12px rgba(0,0,0,0.25); border: 1px solid; }
+.dark .settings-panel { background-color: #1f2937; border-color: #374151; color: #f9fafb; }
+.light .settings-panel { background-color: white; border-color: #e5e7eb; color: #1f2937; }
+.settings-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 2rem; padding-bottom: 1rem; border-bottom: 1px solid; }
+.dark .settings-header { border-color: #374151; }
+.light .settings-header { border-color: #e5e7eb; }
+.settings-title { font-size: 1.5rem; font-weight: bold; }
+.close-button { background: none; border: none; cursor: pointer; padding: 0.5rem; border-radius: 50%; transition: all 0.3s ease; }
+.dark .close-button { color: #9ca3af; background-color: rgba(55,65,81,0.5); }
+.light .close-button { color: #6b7280; background-color: rgba(229,231,235,0.5); }
+.close-button:hover { transform: scale(1.1); }
+.setting-group { margin-bottom: 2rem; }
+.setting-label { display: block; font-weight: 600; margin-bottom: 0.5rem; font-size: 1rem; }
+.setting-description { font-size: 0.875rem; opacity: 0.7; margin-bottom: 1rem; }
+.image-upload-area { border: 2px dashed; border-radius: 0.5rem; padding: 2rem; text-align: center; cursor: pointer; transition: all 0.3s ease; position: relative; }
+.dark .image-upload-area { border-color: #4b5563; background-color: rgba(55,65,81,0.3); }
+.light .image-upload-area { border-color: #d1d5db; background-color: rgba(243,244,246,0.3); }
+.image-upload-area:hover { border-color: #10b981; }
+.image-upload-area.has-image { border-style: solid; border-color: #10b981; }
+.upload-icon { width: 3rem; height: 3rem; margin: 0 auto 1rem; opacity: 0.5; }
+.upload-text { font-weight: 500; margin-bottom: 0.5rem; }
+.upload-hint { font-size: 0.875rem; opacity: 0.7; }
+.image-preview { max-width: 100%; max-height: 150px; border-radius: 0.5rem; margin-bottom: 1rem; }
+.image-actions { display: flex; gap: 0.5rem; justify-content: center; margin-top: 1rem; }
+.action-button { padding: 0.5rem 1rem; border-radius: 0.5rem; border: 1px solid; cursor: pointer; font-size: 0.875rem; transition: all 0.3s ease; }
+.dark .action-button { background-color: #374151; border-color: #4b5563; color: #f9fafb; }
+.light .action-button { background-color: #f3f4f6; border-color: #d1d5db; color: #1f2937; }
+.action-button:hover { transform: translateY(-1px); box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1); }
+.avatar-custom { width: 100%; height: 100%; border-radius: 50%; object-fit: cover; }
+.checkbox-container { display: flex; align-items: center; gap: 0.75rem; margin-top: 1rem; }
+.custom-checkbox { width: 1.25rem; height: 1.25rem; cursor: pointer; accent-color: #10b981; }
+.checkbox-label { cursor: pointer; font-weight: 500; user-select: none; }
+@keyframes bounce { 0%,20%,53%,80%,100% { transform: translate3d(0,0,0); } 40%,43% { transform: translate3d(0,-30px,0); } 70% { transform: translate3d(0,-15px,0); } 90% { transform: translate3d(0,-4px,0); } }


### PR DESCRIPTION
## Summary
- redesign frontend chat UI with dark/light themes and avatar settings
- add settings overlay and theme toggle
- implement markdown rendering and avatar customization

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68405a7f7764833290018b4ef0e70e19