### PR TITLE
Enable CORS for frontend

### DIFF
--- a/src/rd_assistant/api/server.py
+++ b/src/rd_assistant/api/server.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from uuid import uuid4
 from typing import Dict
@@ -11,6 +12,13 @@ from ..core.analyzer import RequirementAnalyzer
 from ..core.storage import SessionStorage
 
 app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 # Initialize core services
 config = Config()


### PR DESCRIPTION
## Summary
- add `CORSMiddleware` to allow browser clients to call the API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405ea27ed083329b5f5e8989edc4b4